### PR TITLE
Update PKGBUILD

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,61 +1,46 @@
 # Maintainer: Jesse McClure AKA "Trilby" <jmcclure [at] cns [dot] umass [dot] edu>
 pkgname=ttwm-git
 _gitname="ttwm"
-pkgver=175
+pkgver=0.181.1a63f31
+pkgver() { cd "${srcdir}/$_gitname"; echo 0."$(git rev-list --count HEAD)"."$(git describe --always)" }
 pkgrel=1
+epoch=1
 pkgdesc="Tiny Tiler/Tabbed Tiler Window Manager"
 url="http://github.com/TrilbyWhite/ttwm.git"
 arch=('any')
 license=('GPLv3')
 depends=('libx11' 'libxrandr')
 makedepends=('git')
-source=("$_gitname::git+git://github.com/TrilbyWhite/ttwm.git")
+source=("$_gitname::git://github.com/TrilbyWhite/ttwm.git")
 sha256sums=('SKIP')
 
-pkgver() {
-	cd $_gitname
-	git rev-list HEAD --count
-}
-
 prepare() {
-	cd $_gitname
-	## Check XDG_CONFIG_HOME
-	if [[ -f $XDG_CONFIG_HOME/ttwm/config.h ]]; then
-		msg "Using user config from $XDG_CONFIG_HOME/config.h"
-		msg "  Be sure to check for changes to default config.h"
-		cp $XDG_CONFIG_HOME/ttwm/config.h ./config.h
-	else
-		msg "Using default config"
-	fi
-	if [[ -f $XDG_CONFIG_HOME/ttwm/icons.h ]]; then
-		msg "Using user icons from $XDG_CONFIG_HOME/icons.h"
-		cp $XDG_CONFIG_HOME/ttwm/icons.h ./icons.h
-	else
-		msg "Using default icons"
-	fi
-	## Check ~
-	if [[ -f /.ttwm_conf.h ]]; then
-		msg "Using user config from ~/.ttwm_conf.h"
-		msg "  Be sure to check for changes to default config.h"
-		cp ~/.ttwm_conf.h ./config.h
-	else
-		msg "Using default config"
-	fi
-	if [[ -f ~/.ttwm_icons.h ]]; then
-		msg "Using user icons from ~/.ttwm_icons.h"
-		cp ~/.ttwm_icons.h ./icons.h
-	else
-		msg "Using default icons"
+	for config in {"$HOME"/.ttwm_,"$XDG_CONFIG_HOME"/ttwm/}{config,icons}.h; do
+		if [[ -f "$config" ]]; then
+			case "$config" in
+				*config.h)
+					cp "$config" "${srcdir}"/ttwm/config.h
+					echo "Using configuration from $config"
+					echo "Check the default config.h for changes"
+					;;
+				*icons.h)
+					cp "$config" "${srcdir}"/ttwm/icons.h
+					echo "Using icons from $config"
+					;;
+			esac
+		fi
+	done
+	if [[ ! -f "$HOME"/.ttwm_config.h && ! -f "$HOME"/.ttwm_icons.h && ! -f "$XDG_CONFIG_HOME"/ttwm/config.h && ! -f "$XDG_CONFIG_HOME"/ttwm/icons.h ]]; then
+		echo "No customizations found; Using defaults"
 	fi
 }
 
 build() {
-	cd $_gitname
+	cd "$_gitname"
 	make
 }
 
 package() {
 	cd "$_gitname"
-	make PREFIX=/usr DESTDIR=$pkgdir install
+	make PREFIX=/usr DESTDIR="${pkgdir}" install
 }
-


### PR DESCRIPTION
This PKGBUILD is updated for the new VCS syntax for makepkg 4.1, and includes dynamic checking for config/icons location and usage. It shaves about 15 lines off the current PKGBUILD. As mentioned in #19, this will require a user config in `$HOME` to be named `.ttwm_config.h`.

The final check to return to the user that no customizations were found is rather long and gross, but I could not think of a better way of doing it.
