### PR TITLE
Initialize Client *b to NULL

### DIFF
--- a/src/actions.c
+++ b/src/actions.c
@@ -55,7 +55,7 @@ void focus(Client *t, const char **arg) {
 		return;
 	}
 	Container *C;
-	Client *c, *a, *b;
+	Client *c, *a, *b = NULL;
 	if (!(c=winmarks[1])) return;
 	if (strncasecmp(arg[0],"flo",3)==0) { /* focus floating */
 		for (a = winmarks[1]->next; a; a = a->next)


### PR DESCRIPTION
Issuing a focus up command when at the top of the client list caused
a crash due to Client *b not being initialized
